### PR TITLE
Fix README license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ We welcome contributions and suggestions! Feel free to open an issue or submit a
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details.
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary
- update the license link in README to use `LICENSE`

## Testing
- `pytest -q` *(fails: command not found)*