### PR TITLE
Add pytest workflow and basic error image test

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,18 @@
+name: Python package
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - run: pip install -r requirements.txt
+    - run: pip install pytest
+    - run: pytest -v

--- a/tests/test_error_image.py
+++ b/tests/test_error_image.py
@@ -1,0 +1,10 @@
+import pytest
+
+from TeslaThermalCam import generate_error_image
+
+
+def test_generate_error_image_returns_nonempty_bytes():
+    pytest.importorskip('cv2')
+    data = generate_error_image('test error')
+    assert isinstance(data, (bytes, bytearray))
+    assert len(data) > 0


### PR DESCRIPTION
## Summary
- add a workflow to run pytest
- test that `generate_error_image` returns nonempty bytes

## Testing
- `pip install pytest` *(fails: Could not connect to proxy)*
- `python3 -m pytest` *(fails: No module named pytest)*