### PR TITLE
Improve frame generator waiting logic and add regression test

### DIFF
--- a/TeslaThermalCam.py
+++ b/TeslaThermalCam.py
@@ -127,11 +127,16 @@ def generate_frames():
     global latest_frame
     while True:
         with frame_lock:
-            while latest_frame is None:
-                time.sleep(0.1)  # wait for the first frame
-            frame_copy = copy.deepcopy(latest_frame)
-            yield (b'--frame\r\n'
-                   b'Content-Type: image/jpeg\r\n\r\n' + frame_copy + b'\r\n')
+            frame_copy = copy.deepcopy(latest_frame) if latest_frame is not None else None
+
+        if frame_copy is None:
+            time.sleep(0.1)  # wait for the first frame without holding the lock
+            continue
+
+        yield (
+            b"--frame\r\n"
+            b"Content-Type: image/jpeg\r\n\r\n" + frame_copy + b"\r\n"
+        )
         time.sleep(0.1)  # reduce CPU usage
 
 @app.route('/')

--- a/tests/test_error_image.py
+++ b/tests/test_error_image.py
@@ -1,6 +1,13 @@
 import pytest
+import argparse
+from unittest import mock
 
-from TeslaThermalCam import generate_error_image
+pytest.importorskip('flask')
+pytest.importorskip('numpy')
+pytest.importorskip('cv2')
+
+with mock.patch.object(argparse.ArgumentParser, 'parse_args', return_value=argparse.Namespace(device=0)):
+    from TeslaThermalCam import generate_error_image
 
 
 def test_generate_error_image_returns_nonempty_bytes():

--- a/tests/test_generate_frames.py
+++ b/tests/test_generate_frames.py
@@ -1,0 +1,34 @@
+import threading
+import time
+import argparse
+from unittest import mock
+import pytest
+
+pytest.importorskip('flask')
+pytest.importorskip('numpy')
+pytest.importorskip('cv2')
+
+with mock.patch.object(argparse.ArgumentParser, 'parse_args', return_value=argparse.Namespace(device=0)):
+    import TeslaThermalCam as app_module
+    from TeslaThermalCam import generate_frames, frame_lock
+
+
+def test_generate_frames_yields_when_frame_updated():
+    # Ensure shared state starts clean
+    app_module.latest_frame = None
+
+    gen = generate_frames()
+
+    def update_frame():
+        time.sleep(0.2)
+        with frame_lock:
+            app_module.latest_frame = b"fakejpg"
+
+    t = threading.Thread(target=update_frame)
+    t.start()
+
+    frame = next(gen)
+    gen.close()
+    t.join()
+
+    assert b"fakejpg" in frame


### PR DESCRIPTION
## Summary
- avoid holding the lock while waiting for the first frame
- sleep outside the lock when no frame is available
- add regression test for frame generator
- update existing test to patch command line parsing and dependencies

## Testing
- `pytest -q`