### PR TITLE
Improve error image scaling

### DIFF
--- a/TeslaThermalCam.py
+++ b/TeslaThermalCam.py
@@ -64,6 +64,10 @@ def generate_error_image(message):
 
     if not wrapped_text:  # if the message is too long to fit in the image
         font_scale = 0.4  # reduce the font size
+        # recalculate sizing metrics based on the new font scale
+        char_size, _ = cv2.getTextSize('a', font, font_scale, font_thickness)
+        char_width = char_size[0]
+        max_chars = image.shape[1] // char_width
         wrapped_text = textwrap.wrap(message, width=max_chars)
 
     line_height = char_size[1] + 5  # 5 pixels for spacing between lines

--- a/tests/test_error_image.py
+++ b/tests/test_error_image.py
@@ -1,10 +1,25 @@
 import pytest
 
+pytest.importorskip('flask')
+pytest.importorskip('cv2')
+
 from TeslaThermalCam import generate_error_image
 
 
 def test_generate_error_image_returns_nonempty_bytes():
-    pytest.importorskip('cv2')
     data = generate_error_image('test error')
     assert isinstance(data, (bytes, bytearray))
     assert len(data) > 0
+
+
+def test_generate_error_image_handles_long_message():
+    long_message = ' '.join(['error'] * 100)
+    data = generate_error_image(long_message)
+    assert isinstance(data, (bytes, bytearray))
+    assert len(data) > 0
+    import numpy as np
+    import cv2
+    img_array = np.frombuffer(data, dtype=np.uint8)
+    image = cv2.imdecode(img_array, cv2.IMREAD_COLOR)
+    assert image is not None
+    assert image.shape == (192, 256, 3)


### PR DESCRIPTION
## Summary
- recalc text metrics after font size adjustments in `generate_error_image`
- test long error messages are handled

## Testing
- `pytest -q` *(fails: 1 skipped)*