### PR TITLE
Add camera device configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ Or use `docker-compose` for a one-command setup (includes Watchtower for updates
 docker-compose up -d
 ```
 
+By default the stack expects your camera at `/dev/video0` and uses camera index
+`0`. Set the environment variables `CAMERA_DEVICE` and `CAMERA_INDEX` before
+running `docker-compose` to override these values. Example:
+
+```bash
+CAMERA_DEVICE=/dev/video1 CAMERA_INDEX=1 docker-compose up -d
+```
+
 The application listens on port `5001` by default as defined in `TeslaThermalCam.py`.
 
 ## Hardware Components

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@ services:
         ports:
             - "5001:5001"
         devices:
-            - "/dev/video0:/dev/video0"
+            - "${CAMERA_DEVICE:-/dev/video0}:/dev/video0"
+        command: python TeslaThermalCam.py --device ${CAMERA_INDEX:-0}
         restart: always
 
     watchtower:


### PR DESCRIPTION
## Summary
- accept a configurable camera device in `docker-compose.yml`
- document how to override the camera device and index

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'TeslaThermalCam')*